### PR TITLE
Ensure buffer is in org-mode before calling org-dotemacs-load-blocks

### DIFF
--- a/org-dotemacs.el
+++ b/org-dotemacs.el
@@ -567,6 +567,7 @@ The optional argument ERROR-HANDLING determines how errors are handled and takes
             ;; Hack: write the buffer out first to prevent org-babel-pre-tangle-hook
             ;; prompting for a filename to save it in.
             (write-file (concat temporary-file-directory (buffer-name)))
+	    (org-mode)
             (org-dotemacs-load-blocks target-file error-handling)
             (delete-file (concat temporary-file-directory (buffer-name))))
           (kill-buffer matchbuf))


### PR DESCRIPTION
Without this, org-dotemacs appears to break on emacs 26.1