### PR TITLE
Fix tag matching by ensuring org-dotemacs checks for exact (instead of partial) tag matches

### DIFF
--- a/org-dotemacs.el
+++ b/org-dotemacs.el
@@ -281,9 +281,9 @@ argument '--tag-match'.")
 (defun org-dotemacs-default-match nil
   "Return the default tag match string based on items in `org-dotemacs-conditional-tags' (which see)."
   (let ((str (cl-loop for (regex . condition) in org-dotemacs-conditional-tags
-                      if (not (eval condition)) concat (concat regex "\\|"))))
+                      if (not (eval condition)) concat (concat regex "$\\|^"))))
     (if (not (equal str ""))
-        (concat "-{\\(?:" (substring str 0 -2) "\\)}"))))
+        (concat "-{\\(?:^" (substring str 0 -3) "\\)}"))))
 
 ;; The following function is based on code from el-get-dependencies.el : https://github.com/dimitri/el-get/
 ;; simple-call-tree-info: DONE


### PR DESCRIPTION
`org-dotemacs-default-match` generates a regex to check for excluded tags. However, right now it counts partial matches, which is a problem. For instance, if you’re not on a Mac, the default behavior is to ignore code blocks under headings with the “mac” tag. But, this works a little too well: under the same circumstances, it will ignore code blocks under headings with the tag “emacs”, because the string contains “mac”. This fixes that problem by changing how the regex is generated, adding the `^` and `$` (start and end) symbols around each excluded tag to ensure an exact match.