### PR TITLE
Prevent error when body of a source block is empty

### DIFF
--- a/org-dotemacs.el
+++ b/org-dotemacs.el
@@ -430,7 +430,7 @@ The optional argument ERROR-HANDLING determines how errors are handled and takes
 		      (depends (org-entry-get beg-block "DEPENDS" org-dotemacs-dependency-inheritance)))
 		  (push (cons name (and depends (split-string depends "[[:space:]]+"))) graph)
 		  (push (point) positions)
-		  (push (cons name (substring-no-properties body)) blocks)))))
+		  (push (cons name (substring-no-properties (or body ""))) blocks)))))
 	(let ((efile (expand-file-name file))
 	      (blkalist (cl-loop for blk in (mapcar 'car graph)
 				 for pos in positions


### PR DESCRIPTION
This is a simple change. Before, if you had an empty Elisp source block in your configuration (like as a placeholder or something), `org-babel-map-src-blocks` would bind `body` to nil, `org-dotemacs-load-file` would send `body` to `buffer-substring-no-properties`, which, expecting a string, would choke on the nil value.

(In times like this, I miss Python’s polymorphism… but I still prefer Lisp’s nests of parentheses to Python’s ziggurat of tabs.)